### PR TITLE
feat: add mermaid theme toggle (auto / light / dark)

### DIFF
--- a/src/contents/exporter.tsx
+++ b/src/contents/exporter.tsx
@@ -1,11 +1,19 @@
+import { useEffect, useState } from "react";
 import { DocumentCopyFilled } from "@fluentui/react-icons";
 import cssText from "data-text:./style.css";
 import type { PlasmoCSConfig } from "plasmo";
+import type { Mermaid } from "mermaid";
 
 import { sendToBackground } from "@plasmohq/messaging";
 
-import { rawDataKey } from "~core/render";
-import { enableSandbox } from "~core/options";
+import { rawDataKey, rerenderAll } from "~core/render";
+import {
+  cycleTheme,
+  enableSandbox,
+  getThemeSetting,
+  setThemeSetting,
+} from "~core/options";
+import type { ThemeSetting } from "~types";
 
 // noinspection JSUnusedGlobalSymbols
 export const config: PlasmoCSConfig = {
@@ -128,6 +136,32 @@ const unescapeHTML = (str) => {
 };
 
 const ExportButton = () => {
+  const [theme, setTheme] = useState<ThemeSetting>("auto");
+
+  useEffect(() => {
+    getThemeSetting().then((saved) => setTheme(saved));
+  }, []);
+
+  const themeIcon =
+    theme === "light" ? "☀︎" : theme === "dark" ? "☾" : "A";
+  const themeTitle =
+    theme === "light"
+      ? "Mermaid theme: Light · Click for Dark"
+      : theme === "dark"
+        ? "Mermaid theme: Dark · Click for Auto"
+        : "Mermaid theme: Auto (follows system) · Click for Light";
+
+  const onToggleTheme = async () => {
+    const next = cycleTheme(theme);
+    await setThemeSetting(next);
+    setTheme(next);
+    // @ts-ignore
+    const mermaid = window.mermaid as Mermaid;
+    if (mermaid) {
+      await rerenderAll(mermaid);
+    }
+  };
+
   return (
     <div className={"flex flex-col gap-y-1"}>
       <button
@@ -172,6 +206,14 @@ const ExportButton = () => {
         type="button"
         className="text-xl border box-border border-gray-80 text-gray-100 bg-gray-10 hover:bg-gray-30 rounded">
         <DocumentCopyFilled width="1em" height="1em" />
+      </button>
+      <button
+        id={"theme"}
+        title={themeTitle}
+        onClick={onToggleTheme}
+        type="button"
+        className="text-xl border box-border border-gray-80 text-gray-100 bg-gray-10 hover:bg-gray-30 rounded">
+        <span aria-hidden="true">{themeIcon}</span>
       </button>
     </div>
   );

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -1,6 +1,6 @@
 import { Storage, type StorageCallbackMap, type StorageWatchCallback } from "@plasmohq/storage";
 
-import type { ExcludeConfig, Experimental, SelectorConfig } from "~types";
+import type { ExcludeConfig, Experimental, SelectorConfig, ThemeSetting } from "~types";
 
 const storage = new Storage();
 const storageKeyPrefix = "mermaid-previewer.";
@@ -10,6 +10,7 @@ export const storageKey = {
   matchSelectors: `${storageKeyPrefix}matchSelectors`,
   downloadSelectors: `${storageKeyPrefix}downloadSelectors`,
   experimental: `${storageKeyPrefix}experimental`,
+  theme: `${storageKeyPrefix}theme`,
 };
 
 export const defaultExcludes: ExcludeConfig[] = [
@@ -81,6 +82,50 @@ export const enableSandbox = async (): Promise<boolean> => {
     Experimental | undefined
   >(storageKey.experimental);
   return experimental ? experimental.sandbox : false;
+};
+
+/**
+ * 主题状态循环顺序：light -> dark -> auto
+ */
+const themeCycle: ThemeSetting[] = ["light", "dark", "auto"];
+
+/**
+ * 获取当前主题设置，默认 auto
+ */
+export const getThemeSetting = async (): Promise<ThemeSetting> => {
+  return (await storage.get<ThemeSetting>(storageKey.theme)) ?? "auto";
+};
+
+/**
+ * 保存主题设置（全局持久化）
+ */
+export const setThemeSetting = async (theme: ThemeSetting): Promise<void> => {
+  await storage.set(storageKey.theme, theme);
+};
+
+/**
+ * 解析实际生效的主题：auto 跟随系统深色模式
+ */
+export const getEffectiveTheme = async (): Promise<"light" | "dark"> => {
+  const setting = await getThemeSetting();
+  if (setting === "light") {
+    return "light";
+  }
+  if (setting === "dark") {
+    return "dark";
+  }
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+};
+
+/**
+ * 循环到下一个主题状态
+ */
+export const cycleTheme = (current: ThemeSetting): ThemeSetting => {
+  const index = themeCycle.indexOf(current);
+  const nextIndex = index === -1 ? 0 : (index + 1) % themeCycle.length;
+  return themeCycle[nextIndex];
 };
 
 export const watchStorage = (callback: StorageWatchCallback) => {

--- a/src/core/render.ts
+++ b/src/core/render.ts
@@ -1,7 +1,7 @@
 import { mermaidHover } from "~core/hover";
 
-import { notRenderSelector, queryContainers } from "./selectors";
-import { enableSandbox } from "~core/options";
+import { notRenderSelector, queryContainers, renderedSelector, HadRenderedKey } from "./selectors";
+import { enableSandbox, getEffectiveTheme } from "~core/options";
 import type { Mermaid } from "mermaid";
 
 /**
@@ -62,9 +62,15 @@ export const render = async (
   mermaid: Mermaid,
   domList: HTMLElement[],
 ): Promise<void> => {
+  const effective = await getEffectiveTheme();
+  const theme = effective === "dark" ? "dark" : "default";
+  // 让页面整体跟随当前模式：暗色/亮色（不写死颜色，由浏览器按 color-scheme 渲染）
+  document.documentElement.style.colorScheme =
+    effective === "dark" ? "dark" : "light";
   mermaid.initialize({
     securityLevel: (await enableSandbox()) ? "sandbox" : "strict",
     startOnLoad: false,
+    theme,
   });
   try {
     await mermaid.run({
@@ -74,4 +80,22 @@ export const render = async (
     console.error(e);
   }
   await mermaidHover(domList, false);
+};
+
+/**
+ * 用当前主题重新渲染页面上所有已渲染的mermaid图
+ */
+export const rerenderAll = async (mermaid: Mermaid): Promise<void> => {
+  const mermaidDomList = await queryContainers(
+    document,
+    await renderedSelector(),
+  );
+  for (const mermaidDom of mermaidDomList) {
+    const rawData = mermaidDom.getAttribute(rawDataKey);
+    if (rawData != null) {
+      mermaidDom.innerHTML = rawData;
+      mermaidDom.removeAttribute(HadRenderedKey);
+    }
+  }
+  await render(mermaid, mermaidDomList);
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,3 +10,5 @@ export interface SelectorConfig {
 export interface Experimental {
   sandbox: boolean;
 }
+
+export type ThemeSetting = "auto" | "light" | "dark";


### PR DESCRIPTION
### Problem

Rendered mermaid diagrams always use mermaid's light `default` theme. On a page in dark mode, a diagram without its own `%%{init: {"theme": "dark"}}%%` is invisible — the only workaround is editing the file to add a theme.

### Change

Adds a persisted, global theme control for rendered diagrams.

- **New toolbar button** in the hover exporter (next to download / copy): `☀︎` light, `☾` dark, `A` auto. The icon shows the current mode; hovering shows a tooltip.
- **Cycles** `light → dark → auto` on click. The choice is stored in extension storage, so it persists across sites and browser restarts.
- **`auto`** follows the system's `prefers-color-scheme`, which fixes the original problem out of the box for fresh installs.
- **Applies the theme** to mermaid on render (`theme: "dark"` / `"default"`).
- **Re-renders** all diagrams on the page when the theme changes (`rerenderAll`).
- **Forces the page's `color-scheme`** to match the active mode, so the page canvas flips light/dark consistently — without hardcoding diagram colors or injecting stylesheets.
- Files that set their own mermaid theme still win over the global default.

### Files

- `src/contents/exporter.tsx` — toggle button + re-render trigger
- `src/core/options.ts` — theme storage + helpers (`getThemeSetting`, `setThemeSetting`, `getEffectiveTheme`, `cycleTheme`)
- `src/core/render.ts` — apply theme + `color-scheme`, new `rerenderAll`
- `src/types.ts` — `ThemeSetting` type
